### PR TITLE
use options for removeShortIS and translateGenome instead of setting it on constant.py

### DIFF
--- a/isPredict.py
+++ b/isPredict.py
@@ -240,7 +240,7 @@ def proteinFromNCBI(dnaFiles, dir2proteome):
 	return proteome_files
 
 #def isPredict(args):
-def isPredict(dna_list, path_to_proteome, path_to_hmmsearch_results):
+def isPredict(dna_list, path_to_proteome, path_to_hmmsearch_results, removeShortIS):
 	print('isPredict begins at', datetime.datetime.now().ctime())
 
 	dnaFiles = tools.rdDNAlist(dna_list)
@@ -283,12 +283,13 @@ def isPredict(dna_list, path_to_proteome, path_to_hmmsearch_results):
 			'path_to_proteome': path_to_proteome,
 			'path_to_hmmsearch_results': path_to_hmmsearch_results,
 			'hitsFile': hitsFile,
+			'removeShortIS' : removeShortIS,
 			}
 		pred.pred(args4pred)
-		if constants.removeShortIS == False:
+		if removeShortIS is False:
 			print('Both complete and partial IS elements are reported.')
 		else:
-			print('Only complete IS elements are reported. Please set removeShortIS = False in constants.py if partial IS elements are required.')
+			print('Only complete IS elements are reported.')
 	else:
 		e = 'No hit was returned by HMM search against protein database. ' + datetime.datetime.now().ctime()
 		print(e)

--- a/isPredict.py
+++ b/isPredict.py
@@ -240,13 +240,15 @@ def proteinFromNCBI(dnaFiles, dir2proteome):
 	return proteome_files
 
 #def isPredict(args):
-def isPredict(dna_list, path_to_proteome, path_to_hmmsearch_results, removeShortIS):
+def isPredict(dna_list, path_to_proteome, path_to_hmmsearch_results, removeShortIS, translateGenome):
 	print('isPredict begins at', datetime.datetime.now().ctime())
 
 	dnaFiles = tools.rdDNAlist(dna_list)
-	if constants.translateGenome == True:
+	if translateGenome == True:
+		print ("predict and translate genes from genome sequence into protein database using FragGeneScan program")
 		proteome_files = translateGenomeByFGS_v2(dnaFiles, path_to_proteome)
 	else:
+		print ("use NCBI protein database")
 		proteome_files = proteinFromNCBI(dnaFiles, path_to_proteome)
 
 	clusterSeqFile4phmmer = constants.file4clusterSeqFile4phmmer

--- a/isescan.py
+++ b/isescan.py
@@ -20,7 +20,7 @@ def isPredictSingle(args):
 	with open(filelist, 'w') as fp:
 		fp.write(seqfile+'\n')
 
-	isPredict.isPredict(filelist, path2proteome, path2hmm, args['removeShortIS'])
+	isPredict.isPredict(filelist, path2proteome, path2hmm, args['removeShortIS'], args['translateGenome'])
 	os.remove(filelist)
 
 if __name__ == "__main__":
@@ -40,6 +40,9 @@ if __name__ == "__main__":
 	helpStr= 'remove partial IS elements which include IS element with length < 400 or single copy IS element without perfect TIR.'
 	parser.add_argument('--removeShortIS', action='store_true', help = helpStr)
 
+	helpStr= 'use the protein database from ncbi genome database instead of using FragGeneScan program.'
+	parser.add_argument('--no-FragGeneScan', action='store_false', help = helpStr)
+
 	helpStr = 'sequence file in fasta format'
 	parser.add_argument('seqfile', help = helpStr)
 
@@ -51,12 +54,12 @@ if __name__ == "__main__":
 
 	args = parser.parse_args()
 
-
 	args4isPredictSingle = {
 					'seqfile': args.seqfile,
 					'path2proteome': args.path2proteome,
 					'path2hmm': args.path2hmm,
-					'removeShortIS' : args.removeShortIS 
+					'removeShortIS' : args.removeShortIS,
+					'translateGenome' : args.no_FragGeneScan,
 				}
 
 	isPredictSingle(args4isPredictSingle)

--- a/isescan.py
+++ b/isescan.py
@@ -6,6 +6,7 @@ version = '1.7.1'
 
 import argparse
 import os
+import sys
 
 import isPredict
 
@@ -19,7 +20,7 @@ def isPredictSingle(args):
 	with open(filelist, 'w') as fp:
 		fp.write(seqfile+'\n')
 
-	isPredict.isPredict(filelist, path2proteome, path2hmm)
+	isPredict.isPredict(filelist, path2proteome, path2hmm, args['removeShortIS'])
 	os.remove(filelist)
 
 if __name__ == "__main__":
@@ -36,6 +37,8 @@ if __name__ == "__main__":
 
 	parser.add_argument('--version', action='version', version='%(prog)s' + ' ' + version)
 
+	helpStr= 'remove partial IS elements which include IS element with length < 400 or single copy IS element without perfect TIR.'
+	parser.add_argument('--removeShortIS', action='store_true', help = helpStr)
 
 	helpStr = 'sequence file in fasta format'
 	parser.add_argument('seqfile', help = helpStr)
@@ -48,10 +51,12 @@ if __name__ == "__main__":
 
 	args = parser.parse_args()
 
+
 	args4isPredictSingle = {
 					'seqfile': args.seqfile,
 					'path2proteome': args.path2proteome,
 					'path2hmm': args.path2hmm,
+					'removeShortIS' : args.removeShortIS 
 				}
 
 	isPredictSingle(args4isPredictSingle)

--- a/pred.py
+++ b/pred.py
@@ -2779,7 +2779,7 @@ def pred(args):
 	mHits = removeFalsePositive(mHits)
 
 	# remove hits that are partial IS elements identified by length, evalue and irId/irLen
-	if constants.removeShortIS == True:
+	if args['removeShortIS'] is True:
 		print('Start removing partial IS elements')
 		mHits = refineHits(mHits)
 		print('Finish removing partial IS elements')


### PR DESCRIPTION
using values from constants.py breaks the ability to for user set  removeShortIS and translateGenome when ISEScan is installed system wide.

on our cluster ISEScan is installed on a shared filesystem mounted read only.

so I had to hack ISEScan in order to provide to our user the ability to toggle the behaviour normaly controled by values from constants.py

regards

Eric


 